### PR TITLE
Improve AI reflection locale handling and softer feedback prompts

### DIFF
--- a/Backend.Tests/AiChatServicePromptTests.cs
+++ b/Backend.Tests/AiChatServicePromptTests.cs
@@ -1,0 +1,53 @@
+using LifeHub.Services;
+using Xunit;
+
+namespace Backend.Tests;
+
+public class AiChatServicePromptTests
+{
+    [Fact]
+    public void BuildSystemPrompt_UsesPreferredLanguageForFirstMessage()
+    {
+        var prompt = InvokeBuildSystemPrompt("ctx", 7, "ru");
+
+        Assert.Contains("The first assistant message MUST be in Russian", prompt);
+    }
+
+    [Fact]
+    public void BuildSystemPrompt_DefaultsToRussianForUnknownLanguage()
+    {
+        var prompt = InvokeBuildSystemPrompt("ctx", 7, "de");
+
+        Assert.Contains("The first assistant message MUST be in Russian", prompt);
+    }
+
+    [Fact]
+    public void BuildSystemPrompt_IncludesSoftFeedbackGuidance()
+    {
+        var prompt = InvokeBuildSystemPrompt("ctx", 14, "en");
+
+        Assert.Contains("Keep feedback collection gentle: invite sharing instead of pressuring for analysis.", prompt);
+        Assert.Contains("A soft, optional", prompt);
+    }
+
+    [Fact]
+    public void BuildSystemPrompt_IncludesPreviousReflectionContinuityGuidance()
+    {
+        var prompt = InvokeBuildSystemPrompt("ctx", 30, "en");
+
+        Assert.Contains("Use continuity: if \"PREVIOUS REFLECTION SUMMARIES\" are present in the context", prompt);
+    }
+
+    private static string InvokeBuildSystemPrompt(string contextText, int periodDays, string preferredLanguage)
+    {
+        var method = typeof(AiChatService).GetMethod(
+            "BuildSystemPrompt",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var result = method!.Invoke(null, [contextText, periodDays, preferredLanguage]) as string;
+        Assert.NotNull(result);
+        return result!;
+    }
+}

--- a/Backend.Tests/LifeHub.Backend.Tests.csproj
+++ b/Backend.Tests/LifeHub.Backend.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Backend/LifeHub-Backend.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Backend/Controllers/AiController.cs
+++ b/Backend/Controllers/AiController.cs
@@ -19,7 +19,10 @@ public class AiController(AiChatService aiChatService) : ControllerBase
             return BadRequest("Period must be between 1 and 90 days.");
 
         var userId = User.GetUserId();
-        var (contextId, contextSummary, message) = await aiChatService.StartReflectionAsync(userId, request.PeriodDays);
+        var (contextId, contextSummary, message) = await aiChatService.StartReflectionAsync(
+            userId,
+            request.PeriodDays,
+            request.Language);
 
         return new StartReflectionResponse(contextId, contextSummary, message);
     }

--- a/Backend/DTOs/AiDTO.cs
+++ b/Backend/DTOs/AiDTO.cs
@@ -2,7 +2,7 @@ using LifeHub.Services;
 
 namespace LifeHub.DTOs;
 
-public record StartReflectionRequest(int PeriodDays);
+public record StartReflectionRequest(int PeriodDays, string? Language = null);
 
 public record StartReflectionResponse(
     Guid ContextId,

--- a/Backend/Services/AiChatService.cs
+++ b/Backend/Services/AiChatService.cs
@@ -15,13 +15,13 @@ public class AiChatService(
     private int MaxSteps => configuration.GetValue("Ai:MaxReflectionSteps", 5);
 
     public async Task<(Guid ContextId, string ContextSummary, string Message)> StartReflectionAsync(
-        Guid userId, int periodDays)
+        Guid userId, int periodDays, string? preferredLanguage = null)
     {
         var reflectionCtx = await contextService.GatherAsync(userId, periodDays);
         var contextText = contextService.FormatAsText(reflectionCtx);
         var contextSummary = contextService.FormatContextSummary(reflectionCtx);
 
-        var systemPrompt = BuildSystemPrompt(contextText, periodDays);
+        var systemPrompt = BuildSystemPrompt(contextText, periodDays, preferredLanguage);
 
         var contextId = Guid.NewGuid();
         PromptCache[contextId] = new CachedPrompt(systemPrompt, DateTimeOffset.UtcNow);
@@ -94,12 +94,19 @@ public class AiChatService(
         chatClient ?? throw new InvalidOperationException(
             "AI is not configured. Set Ai:ApiKey in appsettings or environment variables.");
 
-    private static string BuildSystemPrompt(string contextText, int periodDays)
+    private static string BuildSystemPrompt(string contextText, int periodDays, string? preferredLanguage)
     {
+        var normalizedLanguage = preferredLanguage?.Trim().ToLowerInvariant() switch
+        {
+            "ru" or "russian" => "Russian",
+            "en" or "english" => "English",
+            _ => "Russian"
+        };
+
         return $"""
             You are a thoughtful reflection partner. The user is reviewing the last {periodDays} days of activity
             in LifeHub (tasks, habits, optional addiction tracking, journal excerpts). Be warm and non-judgmental,
-            but prioritize curiosity and specificity over generic wellness check-ins.
+            and prioritize curiosity and specificity over generic wellness check-ins.
 
             Here is the user's activity data for this period:
 
@@ -114,15 +121,21 @@ public class AiChatService(
               completed days, relate a journal excerpt to a task or habit, ask what made a completed task easier
               or harder, or what would change one overdue item next week. Vary the angle each turn — do not repeat
               the same question shape (e.g. avoid asking "how did that feel?" every time).
+            - Keep feedback collection gentle: invite sharing instead of pressuring for analysis. Avoid sounding like
+              an interview checklist ("what helped, what blocked, what to improve" all at once). A soft, optional
+              prompt is preferred (e.g. "If you want, share what stood out for you here.").
             - Offer a brief observation from the data (1–2 sentences) before your question when it helps — e.g.
               interpret balance between completion and backlog, or call out one standout pattern — without lecturing.
             - If the data is sparse, say so briefly and ask one focused question about what happened off-app or
               what they want the next period to look like, still avoiding vague mood-only prompts.
             - Celebrate real wins and name them; for slips (missed habits, overdue tasks, resets), stay compassionate
               and specific, not generic reassurance.
+            - Use continuity: if "PREVIOUS REFLECTION SUMMARIES" are present in the context, factor them into your
+              observations and avoid re-asking the same angle from earlier reflections unless the user brings it up.
 
             Dialogue:
-            - Respond in the same language the user writes in.
+            - The first assistant message MUST be in {normalizedLanguage} (from app settings for this reflection start).
+            - After the first assistant message, continue in the same language the user writes in.
             - Keep each reply concise (about 2–4 sentences before the single question, or slightly longer only for the final wrap-up).
             - Build on prior user answers; do not re-ask about topics they already addressed unless adding a new angle.
 

--- a/Backend/Services/ReflectionContextService.cs
+++ b/Backend/Services/ReflectionContextService.cs
@@ -7,7 +7,8 @@ public record ReflectionContext(
     TasksSummary Tasks,
     HabitsSummary Habits,
     AddictionsSummary Addictions,
-    List<string> RecentJournalExcerpts
+    List<string> RecentJournalExcerpts,
+    List<string> PreviousReflectionSummaries
 );
 
 public record TasksSummary(
@@ -52,8 +53,9 @@ public class ReflectionContextService(ApplicationContext context)
         var habits = await GatherHabitsAsync(userId, dateStart, today);
         var addictions = await GatherAddictionsAsync(userId, dateStart, today);
         var journal = await GatherJournalAsync(userId, periodStart);
+        var previousReflections = await GatherPreviousReflectionsAsync(userId, periodStart);
 
-        return new ReflectionContext(tasks, habits, addictions, journal);
+        return new ReflectionContext(tasks, habits, addictions, journal, previousReflections);
     }
 
     private async Task<TasksSummary> GatherTasksAsync(Guid userId, DateTimeOffset periodStart, DateTimeOffset now)
@@ -155,6 +157,23 @@ public class ReflectionContextService(ApplicationContext context)
             .ToList();
     }
 
+    private async Task<List<string>> GatherPreviousReflectionsAsync(Guid userId, DateTimeOffset periodStart)
+    {
+        // SQLite does not support DateTimeOffset in WHERE/ORDER BY; load and sort/filter in memory
+        var entries = await context.JournalEntries
+            .AsNoTracking()
+            .Where(e => e.UserId == userId)
+            .ToListAsync();
+
+        return entries
+            .Where(e => e.CreatedAt < periodStart)
+            .OrderByDescending(e => e.CreatedAt)
+            .Take(3)
+            .Select(e => e.Text.Length > 220 ? e.Text[..220] + "..." : e.Text)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+    }
+
     public string FormatAsText(ReflectionContext ctx)
     {
         var lines = new List<string>();
@@ -190,6 +209,16 @@ public class ReflectionContextService(ApplicationContext context)
             foreach (var excerpt in ctx.RecentJournalExcerpts)
             {
                 lines.Add($"- {excerpt}");
+            }
+        }
+
+        if (ctx.PreviousReflectionSummaries.Count > 0)
+        {
+            lines.Add("");
+            lines.Add("=== PREVIOUS REFLECTION SUMMARIES ===");
+            foreach (var summary in ctx.PreviousReflectionSummaries)
+            {
+                lines.Add($"- {summary}");
             }
         }
 

--- a/Frontend/src/api/ReflectionAPI.ts
+++ b/Frontend/src/api/ReflectionAPI.ts
@@ -7,9 +7,13 @@ export type SendReflectionMessageRequest = components['schemas']['SendReflection
 export type ReflectionMessageResponse = components['schemas']['ReflectionMessageResponse'];
 export type ChatMessageDTO = components['schemas']['ChatMessageDTO'];
 
-export async function startReflection(periodDays: number): Promise<StartReflectionResponse> {
+export async function startReflection(
+    periodDays: number,
+    language?: StartReflectionRequest['language']
+): Promise<StartReflectionResponse> {
     const { data } = await api.post<StartReflectionResponse>('/ai/reflection/start', {
-        periodDays
+        periodDays,
+        language
     });
     return data;
 }

--- a/Frontend/src/api/schema.ts
+++ b/Frontend/src/api/schema.ts
@@ -2075,6 +2075,7 @@ export interface components {
         StartReflectionRequest: {
             /** Format: int32 */
             periodDays: number | string;
+            language?: null | string;
         };
         StartReflectionResponse: {
             /** Format: uuid */

--- a/Frontend/src/components/ReflectionDialog.vue
+++ b/Frontend/src/components/ReflectionDialog.vue
@@ -14,7 +14,7 @@ import {
 } from '@/api/ReflectionAPI'
 import BaseDrawer from '@/components/base/BaseDrawer.vue'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const journalStore = useJournalStore()
 
 const emit = defineEmits<{
@@ -71,7 +71,8 @@ async function selectPeriod(days: number) {
   errorText.value = ''
 
   try {
-    const res = await startReflection(days)
+    const language = locale.value === 'en' ? 'en' : 'ru'
+    const res = await startReflection(days, language)
     contextId.value = res.contextId!
     messages.value = [{ role: 'assistant', content: res.message ?? '' }]
     journalSummary.value = null

--- a/LifeHub.sln
+++ b/LifeHub.sln
@@ -6,6 +6,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Backend", "Backend", "{1AE8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LifeHub-Backend", "Backend\LifeHub-Backend.csproj", "{29C4253E-A6E6-6203-E72C-CB68D11D087A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LifeHub.Backend.Tests", "Backend.Tests\LifeHub.Backend.Tests.csproj", "{A5315B3D-909B-4C83-AEF7-D56C2D9986AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,12 +18,17 @@ Global
 		{29C4253E-A6E6-6203-E72C-CB68D11D087A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29C4253E-A6E6-6203-E72C-CB68D11D087A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29C4253E-A6E6-6203-E72C-CB68D11D087A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5315B3D-909B-4C83-AEF7-D56C2D9986AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5315B3D-909B-4C83-AEF7-D56C2D9986AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5315B3D-909B-4C83-AEF7-D56C2D9986AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5315B3D-909B-4C83-AEF7-D56C2D9986AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{29C4253E-A6E6-6203-E72C-CB68D11D087A} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
+		{A5315B3D-909B-4C83-AEF7-D56C2D9986AA} = {1AE8ACA6-933B-BF2A-3671-3E2EAC007D16}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A2964D05-C6DD-41F7-817A-382FBEF666C8}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Pass selected app language (`en`/`ru`) from the reflection UI to `POST /api/ai/reflection/start`.
- Extend `StartReflectionRequest` with optional `language` and pass it into `AiChatService`.
- Update reflection system prompt so the **first assistant message** is forced to the selected language from app settings.
- Make feedback collection prompts softer in the system prompt (less checklist/interrogation style, more optional/gentle invites).
- Add prior journal context block (`PREVIOUS REFLECTION SUMMARIES`) so AI can keep continuity and avoid repeating old angles.
- Add backend prompt-focused unit tests to verify language fallback, softer guidance, and continuity guidance.

## Scope notes
- No DB schema changes.
- Existing unrelated changes in `Frontend/package-lock.json` were left untouched.

## Validation executed
- Regenerated frontend OpenAPI schema due DTO contract update.
- Ran backend build + prompt tests.
- Ran frontend type-check + production build.
- Attempted manual UI validation, but full reflection response verification is blocked in this environment without a valid OpenAI API key configured in backend secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53ef5714-132d-454c-9a55-f83f0b30b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53ef5714-132d-454c-9a55-f83f0b30b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

