### PR TITLE
Fix habit streak chip alignment without goal

### DIFF
--- a/Frontend/src/components/HabitCard.vue
+++ b/Frontend/src/components/HabitCard.vue
@@ -120,12 +120,12 @@ const emit = defineEmits<{
 .goal-streak-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
 }
 
 .habit-streak-chip {
+  margin-left: auto;
   padding: 0.1rem 0.5rem;
   border-radius: 999px;
   background-color: var(--p-primary-100);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix alignment in `HabitCard` so streak chip always stays on the right edge, even when goal text is absent
- keep goal text truncation behavior unchanged

## Testing
- `npm run build` (Frontend)
- manual UI verification in browser for habit card without goal

## Walkthrough Artifacts
[habit_streak_chip_right_without_goal_full_flow_demo.mp4](https://cursor.com/agents/bc-32824925-0a86-4683-8f73-ebb7808a0505/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhabit_streak_chip_right_without_goal_full_flow_demo.mp4)
[Habit card without goal keeps streak chip on the right](https://cursor.com/agents/bc-32824925-0a86-4683-8f73-ebb7808a0505/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhabit_streak_chip_right_without_goal_full_flow.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32824925-0a86-4683-8f73-ebb7808a0505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32824925-0a86-4683-8f73-ebb7808a0505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

