### PR TITLE
Hide NSFW-linked JournalEntry cards when NSFW mode is off

### DIFF
--- a/Frontend/src/views/GoalsView.vue
+++ b/Frontend/src/views/GoalsView.vue
@@ -80,9 +80,17 @@ const addictionsByGoalId = computed(() => {
   return grouped
 })
 
+const addictionsById = computed(
+  () => new Map(addictionsStore.addictions.map((row) => [row.addiction.id, row.addiction]))
+)
+
 const entriesByGoalId = computed(() => {
   const grouped: Record<string, JournalEntryDTO[]> = {}
   for (const entry of journalStore.entries) {
+    if (entry.addictionId) {
+      const addiction = addictionsById.value.get(entry.addictionId)
+      if (addiction && !nsfwContentStore.addictionVisible(addiction)) continue
+    }
     if (!entry.goalId) continue
     let bucket = grouped[entry.goalId]
     if (!bucket) {

--- a/Frontend/src/views/JournalView.vue
+++ b/Frontend/src/views/JournalView.vue
@@ -47,6 +47,17 @@ const addictionOptions = computed(() => [
     .map((a) => ({ label: a.addiction.title, value: a.addiction.id }))
 ]);
 
+const addictionsById = computed(
+  () => new Map(addictionsStore.addictions.map((row) => [row.addiction.id, row.addiction]))
+);
+
+function journalEntryVisible(entry: JournalEntryDTO) {
+  if (!entry.addictionId) return true;
+  const addiction = addictionsById.value.get(entry.addictionId);
+  if (!addiction) return true;
+  return nsfwContentStore.addictionVisible(addiction);
+}
+
 watch(
   () =>
     `${nsfwContentStore.showNsfwContent}|${addictionsStore.addictions
@@ -61,7 +72,7 @@ watch(
 );
 
 const filteredEntries = computed(() => {
-  let list = journalStore.entries;
+  let list = journalStore.entries.filter(journalEntryVisible);
 
   const q = searchQuery.value.trim().toLowerCase();
   if (q) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Added NSFW visibility filtering for journal entries in `JournalView`: entries linked to NSFW addictions are now hidden when NSFW mode is disabled.
- Applied the same filtering for goal-scoped journal entries in `GoalsView` to keep behavior consistent across screens.

## Why
Previously, disabling NSFW mode hid only addiction cards, while `JournalEntry` cards linked to those addictions could still remain visible.

## Scope
- Frontend only (`JournalView.vue`, `GoalsView.vue`).
- No API contract or backend changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6758bb3-5820-466d-975e-a1d444a0ecf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6758bb3-5820-466d-975e-a1d444a0ecf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

